### PR TITLE
feat: use renderError regardless of the context(html or json)

### DIFF
--- a/lib/shared/error_handler.js
+++ b/lib/shared/error_handler.js
@@ -39,13 +39,10 @@ module.exports = function getErrorHandler(provider, eventName) {
         ctx.oidc.session.device = { secret };
         await userCodeInputSource(ctx, formHtml.input(provider.pathFor('code_verification'), secret, err.userCode, charset), out, err);
         if (err instanceof ReRenderError) return; // render without emit
-      } else if (ctx.accepts('json', 'html') === 'html') {
-        // this ^^ makes */* requests respond with json (curl, xhr, request libraries), while in
-        // browser requests end up rendering the html error instead
+      } else {
+        // always use renderError
         const renderError = instance(provider).configuration('renderError');
         await renderError(ctx, out, err);
-      } else {
-        ctx.body = out;
       }
 
       if (out.error === 'server_error') {


### PR DESCRIPTION
We need this for two reasons:

1. To be able to log the error and respond with a request id. This will make troubleshooting easier.
2. To hide the error details and eliminate the (theoretical) possibility for a brute-force attack