### PR TITLE
feat: allow native app protocols on web clients

### DIFF
--- a/lib/helpers/client_schema.js
+++ b/lib/helpers/client_schema.js
@@ -486,9 +486,11 @@ module.exports = function getSchema(provider) {
 
         switch (this.application_type) { // eslint-disable-line default-case
           case 'web': {
-            if (!['https:', 'http:'].includes(protocol)) {
-              invalidate('redirect_uris must only contain web uris');
-            }
+            // Disable protocol validation on web clients.
+            // Allows native apps and web apps to share the same client id
+            // if (!['https:', 'http:'].includes(protocol)) {
+            //   invalidate('redirect_uris must only contain web uris');
+            // }
 
             if (this.grant_types.includes('implicit') && protocol === 'http:') {
               invalidate('redirect_uris for web clients using implicit flow MUST only register URLs using the https scheme');


### PR DESCRIPTION
Allows a native app and web app to share the same client id